### PR TITLE
fix typo + 401 JSON response

### DIFF
--- a/spec/script_spec.js
+++ b/spec/script_spec.js
@@ -79,9 +79,11 @@ describe('handleError', function(){
       createIssue("temp", "blake41", "BIG ISSUE", "the biggest issue ever!!");
       var response = {
         "status": 401, 
-        "contentType": 'text/plain',
-        "responseText" : "unauth",
-        "statusText": "Unathorized"
+        "responseText": {
+          "message": "Bad credentials",
+          "documentation_url": "https://developer.github.com/v3"
+        },
+      "statusText": "Unauthorized"
       }
       jasmine.Ajax.requests.mostRecent().respondWith(response);
       expect(window.handleError).toHaveBeenCalled();


### PR DESCRIPTION
- No `contentType` member in the JSON object returned from GitHub upon a 401
- `responseText` member points to an object; not a string
- Unathorized --> Unauthorized
